### PR TITLE
Small typo in graph.py

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -7,7 +7,7 @@ def trace(data, mode = 'markers', name="data"):
     y_values = list(map(lambda point: point['y'],data))
     return {'x': x_values, 'y': y_values, 'mode': mode, 'name': name}
 
-def line_function_trace(line_function, x_values, mode = 'line', name = 'line function'):
+def line_function_trace(line_function, x_values, mode = 'lines', name = 'line function'):
     values = line_function_data(line_function, x_values)
     values.update({'mode': mode, 'name': name})
     return values


### PR DESCRIPTION
The mode for line_function_trace() should have default value 'lines', not 'line'.